### PR TITLE
Updates held_duration

### DIFF
--- a/woocommerce-do-not-reduce-renewal-stock.php
+++ b/woocommerce-do-not-reduce-renewal-stock.php
@@ -31,7 +31,6 @@
 */
 
 function wcs_do_not_reduce_renewal_stock( $reduce_stock, $order ) {
-
 	if ( function_exists( 'wcs_order_contains_renewal' ) && wcs_order_contains_renewal( $order ) ) { // Subscriptions v2.0+
 		$reduce_stock = false;
 	} elseif ( class_exists( 'WC_Subscriptions_Renewal_Order' ) && WC_Subscriptions_Renewal_Order::is_renewal( $order ) ) {
@@ -41,3 +40,25 @@ function wcs_do_not_reduce_renewal_stock( $reduce_stock, $order ) {
 	return $reduce_stock;
 }
 add_filter( 'woocommerce_can_reduce_order_stock', 'wcs_do_not_reduce_renewal_stock', 10, 2 );
+
+/**
+ * When user is in the cart and has a Subscription we want to bypass `wc_get_held_stock_quantity` by setting `woocommerce_hold_stock_minutes` option to 0.
+ *
+ * @param bool $hold_stock_minutes The value we might want to modify.
+ *
+ * @return int|boolean
+ *
+ * @link  https://github.com/Prospress/woocommerce-subscriptions-do-not-reduce-stock-on-renewal/issues/3
+ * @since 1.1.0
+ */
+function wcs_maybe_update_woocommerce_hold_stock_minutes( $hold_stock_minutes ) {
+	if ( doing_action( 'woocommerce_check_cart_items' ) && is_callable( 'WC_Subscriptions_Cart', 'cart_contains_subscription' ) ) {
+		if ( WC_Subscriptions_Cart::cart_contains_subscription() ) {
+			return 0;
+		}
+	}
+
+	return $hold_stock_minutes;
+}
+
+add_filter( 'pre_option_woocommerce_hold_stock_minutes', 'wcs_maybe_update_woocommerce_hold_stock_minutes', 10, 1 );

--- a/woocommerce-do-not-reduce-renewal-stock.php
+++ b/woocommerce-do-not-reduce-renewal-stock.php
@@ -6,6 +6,7 @@
  * Author: Prospress Inc.
  * Author URI: https://prospress.com/
  * License: GPLv3
+ * Version: 1.1.0
  *
  * GitHub Plugin URI: Prospress/woocommerce-subscriptions-do-not-reduce-stock-on-renewal
  * GitHub Branch: master


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #3 

---

### Description
This PR allows Subscriptions to be added when there are items `on-hold` that could affect the stock and then avoid customers to purchase the Subscription

### Steps to test: 
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
<!-- Please include screenshots. If you work with Prospress, sign-up for CloudApp via https://prospress.cl.ly -->
1. Create a new simple Subscription product and set the stock to 2-3
1. Purchase it and complete the payment
1. Purchase it again, but this time set the Order to `Pending payment`
1. On `master` try to purchase the Subscription, you won't be able to because there are no available items.
1. Switch to this branch, you should be able to complete the order.

Closes #3 .
