### PR TITLE
Version header required for git-updater

### DIFF
--- a/woocommerce-do-not-reduce-renewal-stock.php
+++ b/woocommerce-do-not-reduce-renewal-stock.php
@@ -9,6 +9,7 @@
  *
  * GitHub Plugin URI: Prospress/woocommerce-subscriptions-do-not-reduce-stock-on-renewal
  * GitHub Branch: master
+ * Version: 1.0.0
  *
  * Copyright 2017 Prospress, Inc.  (email : freedoms@prospress.com)
  *


### PR DESCRIPTION
A version number in the header is:
* generally nice to keep track of updates
* avoids showing the update notice in the dashboard permanently _("There is a new version of WooCommerce Subscriptions Do Not Reduce Stock on Renewal available. [View version 0.0.0 details] or [update now]")_
* makes the plugin compatibile with https://git-updater.com/ to be able to apply future updates easily along side normal WP updates